### PR TITLE
Feature/artworks and orders

### DIFF
--- a/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
@@ -7,9 +7,10 @@ import Table from '@components/shared/Table';
 import IndeterminateCheckbox from '@components/shared/field/IndeterminateCheckbox';
 import SearchInput from '@components/shared/field/SearchField';
 import { formSchema } from '@constants/artists.formSchema';
+import { usefetchPartnerList } from '@data-access/hooks';
 import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import {
   ColumnDef,
   PaginationState,
@@ -19,7 +20,7 @@ import {
 } from '@tanstack/react-table';
 import usePagination, { DOTS } from '@utils/hooks/usePagination';
 import cx from 'classnames';
-import { createPartner, deletePartnerList, fetchPartnerList } from 'data-access/apis/partners.api';
+import { createPartner, deletePartnerList } from 'data-access/apis/partners.api';
 import { ArtistPartner } from 'data-access/models';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
@@ -70,17 +71,7 @@ const Artists = () => {
     router.push(`${pathname}?${searchParams.toString()}`);
   }, [pageIndex, pageSize, searchParams]);
 
-  const dataQuery = useQuery(
-    ['artists', searchParams.toString()],
-    () =>
-      fetchPartnerList({
-        type: 'Artist',
-        keyword: params.get('keyword'),
-        pageIndex: +(params.get('pageIndex') || 0),
-        pageSize: +(params.get('pageSize') || 50),
-      }),
-    { keepPreviousData: true },
-  );
+  const dataQuery = usefetchPartnerList('Artist');
 
   const createMutation = useMutation((data: ArtistPartner) => createPartner(data), {
     onSuccess: () => {

--- a/apps/aki-erp/app/(auth)/(information)/company/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/company/page.tsx
@@ -7,9 +7,10 @@ import Table from '@components/shared/Table';
 import IndeterminateCheckbox from '@components/shared/field/IndeterminateCheckbox';
 import SearchField from '@components/shared/field/SearchField';
 import { formSchema } from '@constants/company.formSchema';
+import { usefetchPartnerList } from '@data-access/hooks';
 import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import {
   ColumnDef,
   PaginationState,
@@ -19,7 +20,7 @@ import {
 } from '@tanstack/react-table';
 import usePagination, { DOTS } from '@utils/hooks/usePagination';
 import cx from 'classnames';
-import { createPartner, deletePartnerList, fetchPartnerList } from 'data-access/apis/partners.api';
+import { createPartner, deletePartnerList } from 'data-access/apis/partners.api';
 import { CompanyPartner } from 'data-access/models';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
@@ -70,17 +71,7 @@ const Company = () => {
     router.push(`${pathname}?${searchParams.toString()}`);
   }, [pageIndex, pageSize, searchParams]);
 
-  const dataQuery = useQuery(
-    ['company', searchParams.toString()],
-    () =>
-      fetchPartnerList({
-        type: 'Company',
-        keyword: searchParams.get('keyword'),
-        pageIndex: +(searchParams.get('pageIndex') || 0),
-        pageSize: +(searchParams.get('pageSize') || 50),
-      }),
-    { keepPreviousData: true },
-  );
+  const dataQuery = usefetchPartnerList('Company');
 
   const createMutation = useMutation((data: CompanyPartner) => createPartner(data), {
     onSuccess: () => {

--- a/apps/aki-erp/app/(auth)/(procurement)/lend/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/lend/orders/page.tsx
@@ -194,7 +194,7 @@ const LendOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/lend/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/lend/return-orders/page.tsx
@@ -194,7 +194,7 @@ const LendReturnOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/purchase/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/purchase/orders/page.tsx
@@ -173,7 +173,7 @@ const PurchaseOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/purchase/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/purchase/return-orders/page.tsx
@@ -194,7 +194,7 @@ const PurchaseReturnOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/repair/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/repair/orders/page.tsx
@@ -195,7 +195,7 @@ const RepairOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/repair/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/repair/return-orders/page.tsx
@@ -197,7 +197,7 @@ const RepairReturnOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/shipment/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/shipment/orders/page.tsx
@@ -195,7 +195,7 @@ const ShipmentOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/shipment/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/shipment/return-orders/page.tsx
@@ -197,7 +197,7 @@ const ShipmentReturnOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/app/(auth)/(procurement)/transfer/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/transfer/orders/page.tsx
@@ -169,7 +169,7 @@ const TransferOrders = () => {
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/components/artworks/ArtworksBatchUpdateDialog.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksBatchUpdateDialog.tsx
@@ -9,7 +9,7 @@ import { ArtworkDetail, TransferOrder } from '@data-access/models';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { useMutation } from '@tanstack/react-query';
 import { showError, showSuccess } from '@utils/swalUtil';
-import classnames from 'classnames';
+import cx from 'classnames';
 import { useForm } from 'react-hook-form';
 import ArtworksBatchUpdateTable from './ArtworksBatchUpdateTable';
 
@@ -67,7 +67,7 @@ const ArtworksBatchUpdateDialog: React.FC<ArtworksBatchUpdateDialogProsp> = ({
 
   return (
     <div
-      className={classnames('modal absolute z-10', {
+      className={cx('modal absolute z-10', {
         'modal-open': isOpen,
       })}
     >

--- a/apps/aki-erp/components/artworks/ArtworksDetail.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksDetail.tsx
@@ -49,7 +49,7 @@ const schema = yup.object().shape({
   zhName: yup.string().test('artwork name', '作品名稱為必填項目', (value, context) => {
     return value || context.parent?.enName ? true : false;
   }),
-  // imageUrl: yup.string().required('請確認圖片是否已上傳？'),
+  imageUrl: yup.string().required('請確認圖片是否已上傳？'),
   thumbnailUrl: yup.string(),
   countryCode: yup.string().nonNullable().required('國籍為必填項目'),
   artists: yup.array().of(

--- a/apps/aki-erp/components/artworks/ArtworksDetail.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksDetail.tsx
@@ -3,7 +3,6 @@
 import React, { ChangeEvent, useState } from 'react';
 
 import { StoreType, assetsTypeOptions } from '@constants/artwork.constant';
-import classNames from 'classnames';
 import {
   createOrUpdateArtworkDetail,
   fetchArtworkDetailByDisplayId,
@@ -22,6 +21,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { fetchCountryList } from '@data-access/apis/countries.api';
 import { usefetchPartnerList } from '@data-access/hooks';
+import cx from 'classnames';
 import { useParams, useRouter } from 'next/navigation';
 
 const salesInfoDisplayed = true;
@@ -274,7 +274,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
               <div className="relative">
                 <input
                   type="file"
-                  className={classNames('file-input file-input-bordered max-w-xs', {
+                  className={cx('file-input file-input-bordered max-w-xs', {
                     'border-error': errors.imageUrl?.message,
                   })}
                   onChange={handleFileChange}
@@ -314,7 +314,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <div className="bg-base-200 flex flex-wrap items-center gap-1 p-1">
                       <div>
                         <select
-                          className={classNames('select select-bordered w-full max-w-xs text-lg', {
+                          className={cx('select select-bordered w-full max-w-xs text-lg', {
                             'select-error': errors.artists,
                           })}
                           {...register(`artists.${index}.zhName`, {
@@ -338,7 +338,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
 
                       <div>
                         <select
-                          className={classNames('select select-bordered w-full max-w-xs text-lg', {
+                          className={cx('select select-bordered w-full max-w-xs text-lg', {
                             'select-error': errors.artists,
                           })}
                           {...register(`artists.${index}.enName`, {
@@ -394,7 +394,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
               </label>
               <div className="relative">
                 <select
-                  className={classNames('select select-bordered w-full max-w-xs text-lg', {
+                  className={cx('select select-bordered w-full max-w-xs text-lg', {
                     'select-error': errors.metadata?.assetsType,
                   })}
                   data-testid="assetsType"
@@ -427,7 +427,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
               </label>
               <div className="relative">
                 <select
-                  className={classNames('select select-bordered w-full max-w-xs text-lg', {
+                  className={cx('select select-bordered w-full max-w-xs text-lg', {
                     'select-error': errors.metadata?.artworkType,
                   })}
                   {...register('metadata.artworkType')}
@@ -460,7 +460,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <div className="input-group border-base-200 rounded-lg border">
                       <div className="bg-base-200 flex flex-wrap items-center gap-2 p-1">
                         <select
-                          className={classNames('select select-bordered w-full max-w-xs text-lg')}
+                          className={cx('select select-bordered w-full max-w-xs text-lg')}
                           {...register(`metadata.agentGalleries.${index}.name`)}
                         >
                           <option value="" disabled>
@@ -504,7 +504,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
               </label>
               <div className="relative">
                 <select
-                  className={classNames('select select-bordered w-full max-w-xs text-lg', {
+                  className={cx('select select-bordered w-full max-w-xs text-lg', {
                     'select-error': errors.countryCode,
                   })}
                   data-testid="countryCode"
@@ -533,7 +533,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                 </label>
                 <div className="relative flex-1 p-1">
                   <input
-                    className={classNames('input input-bordered w-full max-w-xs', {
+                    className={cx('input input-bordered w-full max-w-xs', {
                       'input-error': errors.metadata?.purchasingUnit,
                     })}
                     data-testid="purchasingUnit"
@@ -552,14 +552,14 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                 <div className="relative flex-1">
                   <div className="flex flex-wrap items-center gap-1 p-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.zhName,
                       })}
                       placeholder="中文名稱"
                       {...register('zhName', { onChange: () => trigger(['enName', 'zhName']) })}
                     />
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.enName,
                       })}
                       placeholder="英文名稱"
@@ -585,7 +585,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <label>長</label>
                     <div className="relative flex-1">
                       <input
-                        className={classNames('input input-bordered w-full max-w-xs', {
+                        className={cx('input input-bordered w-full max-w-xs', {
                           'input-error': errors.metadata?.length,
                         })}
                         data-testid="length"
@@ -603,7 +603,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <label>寬</label>
                     <div className="relative flex-1">
                       <input
-                        className={classNames('input input-bordered w-full max-w-xs', {
+                        className={cx('input input-bordered w-full max-w-xs', {
                           'input-error': errors.metadata?.width,
                         })}
                         data-testid="width"
@@ -621,7 +621,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <label>高</label>
                     <div className="relative flex-1">
                       <input
-                        className={classNames('input input-bordered w-full max-w-xs', {
+                        className={cx('input input-bordered w-full max-w-xs', {
                           'input-error': errors.metadata?.height,
                         })}
                         data-testid="height"
@@ -639,7 +639,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <label className="whitespace-nowrap">自定義尺寸</label>
                     <div className="relative flex-1">
                       <input
-                        className={classNames('input input-bordered w-full max-w-xs', {
+                        className={cx('input input-bordered w-full max-w-xs', {
                           'input-error': errors.metadata?.customSize,
                         })}
                         data-testid="customSize"
@@ -659,7 +659,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                     <label className="whitespace-nowrap">號數</label>
                     <div className="relative flex-1">
                       <input
-                        className={classNames('input input-bordered w-full max-w-xs', {
+                        className={cx('input input-bordered w-full max-w-xs', {
                           'input-error': errors.metadata?.serialNumber,
                         })}
                         data-testid="serialNumber"
@@ -683,7 +683,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                 <div className="relative flex-1">
                   <div className="flex flex-wrap items-center gap-1 p-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.zhMedia,
                       })}
                       placeholder="中文名稱"
@@ -692,7 +692,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                       })}
                     />
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.media,
                       })}
                       placeholder="英文名稱"
@@ -719,7 +719,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                 <label className="font-bold">年代</label>
                 <div className="relative flex-1 p-1">
                   <input
-                    className={classNames('input input-bordered w-full max-w-xs', {
+                    className={cx('input input-bordered w-full max-w-xs', {
                       'input-error': errors.yearAge,
                     })}
                     data-testid="yearAge"
@@ -737,7 +737,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                 </label>
                 <div className="relative flex-1">
                   <input
-                    className={classNames('input input-bordered w-full max-w-xs', {
+                    className={cx('input input-bordered w-full max-w-xs', {
                       'input-error': errors.metadata?.edition,
                     })}
                     data-testid="edition"
@@ -822,7 +822,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                 <div className="flex flex-row gap-2">
                   <div className="relative">
                     <select
-                      className={classNames('select select-bordered text-lg', {
+                      className={cx('select select-bordered text-lg', {
                         'select-error': errors.warehouseId,
                       })}
                       data-testid="warehouseId"
@@ -982,7 +982,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                   </label>
                   <div className="relative flex-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.salesName,
                       })}
                       data-testid="salesName"
@@ -1002,7 +1002,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                   </label>
                   <div className="relative flex-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.salseReciver,
                       })}
                       data-testid="salseReciver"
@@ -1022,7 +1022,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                   </label>
                   <div className="relative flex-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.salesPhone,
                       })}
                       data-testid="salesPhone"
@@ -1042,7 +1042,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                   </label>
                   <div className="relative flex-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.salesAddress,
                       })}
                       data-testid="salesAddress"
@@ -1062,7 +1062,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                   </label>
                   <div className="relative flex-1">
                     <input
-                      className={classNames('input input-bordered w-full max-w-xs', {
+                      className={cx('input input-bordered w-full max-w-xs', {
                         'input-error': errors.metadata?.salesDate,
                       })}
                       data-testid="salesDate"

--- a/apps/aki-erp/components/artworks/ArtworksDetail.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksDetail.tsx
@@ -233,6 +233,9 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
       data.metadata.salesType = 'sold';
     }
 
+    if (data.metadata?.storeType === StoreType.NONE) data.status = Status.Disabled;
+    if (data.metadata?.storeType === StoreType.IN_STOCK) data.status = Status.Enabled;
+
     mutation.mutate(data);
   };
 

--- a/apps/aki-erp/components/artworks/ArtworksDetail.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksDetail.tsx
@@ -43,7 +43,6 @@ const scrollToSalesInfo = () => {
 };
 
 const schema = yup.object().shape({
-  warehouseId: yup.number().required('庫存位置為必填項目'),
   enName: yup.string().test('artwork name', '作品名稱為必填項目', (value, context) => {
     return value || context.parent?.zhName ? true : false;
   }),
@@ -235,6 +234,11 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
 
     if (data.metadata?.storeType === StoreType.NONE) data.status = Status.Disabled;
     if (data.metadata?.storeType === StoreType.IN_STOCK) data.status = Status.Enabled;
+
+    if (data.metadata && data.metadata.storeType !== StoreType.IN_STOCK) {
+      data.warehouseId = -1;
+      data.metadata.warehouseLocation = '';
+    }
 
     mutation.mutate(data);
   };
@@ -830,7 +834,7 @@ const ArtworksDetail = ({ status }: { status: Status }): JSX.Element => {
                           ),
                       })}
                     >
-                      <option disabled>請選擇</option>
+                      <option value={-1}>請選擇</option>
                       <option value={0}>A</option>
                       <option value={1}>B</option>
                       <option value={2}>C</option>

--- a/apps/aki-erp/components/artworks/ArtworksSelector.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksSelector.tsx
@@ -12,7 +12,7 @@ import { CheckIcon, PencilSquareIcon, XMarkIcon } from '@heroicons/react/20/soli
 import { CellContext, ColumnDef } from '@tanstack/react-table';
 import { useArtworkSearches, useArtworkSelectedList } from '@utils/hooks/useArtworkSearches';
 import useArtworksTable, { inputColumn, selectColumn } from '@utils/hooks/useArtworksTable';
-import classnames from 'classnames';
+import cx from 'classnames';
 import { ArtworkDetail, Status } from 'data-access/models';
 import Link from 'next/link';
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components';
@@ -235,7 +235,7 @@ const ArtworksSelector = ({
 
   return (
     <div
-      className={classnames('modal absolute z-10', {
+      className={cx('modal absolute z-10', {
         'modal-open': isOpen,
       })}
     >

--- a/apps/aki-erp/components/artworks/__test__/ArtworksDetail.spec.tsx
+++ b/apps/aki-erp/components/artworks/__test__/ArtworksDetail.spec.tsx
@@ -1,4 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
+import * as NextNavigation from 'next/navigation';
 import { useParams } from 'next/navigation';
 
 import axios from '@contexts/axios';
@@ -11,6 +12,9 @@ import ArtworksDetail from '../ArtworksDetail';
 jest.mock('next/navigation', () => ({
   ...jest.requireActual('next/navigation'),
   useParams: jest.fn(),
+  useSearchParams: jest
+    .fn()
+    .mockReturnValue(new URLSearchParams() as NextNavigation.ReadonlyURLSearchParams),
 }));
 
 const { mockRouter, wrapper } = createTestWrapper();

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -207,9 +206,9 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -224,7 +223,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -211,9 +210,9 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -228,7 +227,7 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -182,9 +181,9 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -199,7 +198,7 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -202,9 +201,9 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -219,7 +218,7 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -208,9 +207,9 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -225,7 +224,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -212,9 +211,9 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -229,7 +228,7 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/shared/Table.tsx
+++ b/apps/aki-erp/components/shared/Table.tsx
@@ -1,5 +1,5 @@
 import { Table, flexRender } from '@tanstack/react-table';
-import classNames from 'classnames';
+import cx from 'classnames';
 import React from 'react';
 import Skeleton from './Skeleton';
 
@@ -20,7 +20,7 @@ const AkiTable: React.FC<TableProps> = ({ table, isLoading }) => {
                   <td
                     key={header.id}
                     colSpan={header.colSpan}
-                    className={classNames('p-2', {
+                    className={cx('p-2', {
                       'min-w-[10rem]': !['select', 'storeType', 'salesType', 'assetsType'].includes(
                         header.id,
                       ),
@@ -53,7 +53,7 @@ const AkiTable: React.FC<TableProps> = ({ table, isLoading }) => {
           {!isLoading && table.getRowModel().rows.length === 0 ? (
             <tr>
               <td colSpan={table.getHeaderGroups()[0].headers.length}>
-              <div className="flex min-h-[3rem] items-center justify-center">No Data.</div>
+                <div className="flex min-h-[3rem] items-center justify-center">No Data.</div>
               </td>
             </tr>
           ) : (

--- a/apps/aki-erp/components/shared/TablePagination.tsx
+++ b/apps/aki-erp/components/shared/TablePagination.tsx
@@ -1,6 +1,6 @@
 import { Table } from '@tanstack/react-table';
 import usePagination, { DOTS } from '@utils/hooks/usePagination';
-import classnames from 'classnames';
+import cx from 'classnames';
 
 function TablePagination<T>({
   table,
@@ -51,7 +51,7 @@ function TablePagination<T>({
         return (
           <button
             key={key}
-            className={classnames('join-item btn hidden w-14 md:block', {
+            className={cx('join-item btn hidden w-14 md:block', {
               'btn-active': Number(pageNumber) - 1 === pageIndex,
             })}
             onClick={() => table.setPageIndex(Number(pageNumber) - 1)}

--- a/apps/aki-erp/components/shared/field/DatePicker/DatePickerField.tsx
+++ b/apps/aki-erp/components/shared/field/DatePicker/DatePickerField.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronUpDownIcon } from '@heroicons/react/20/solid';
-import classNames from 'classnames';
+import cx from 'classnames';
 import React from 'react';
 import {
   Button,
@@ -34,7 +34,7 @@ const DatePickerField = React.forwardRef<HTMLDivElement, DatePickerFieldProps>(
         value={value || null}
         aria-label={name}
         isDisabled={disabled}
-        className={classNames({
+        className={cx({
           'border-error rounded-lg border': errorMsg,
         })}
       >

--- a/apps/aki-erp/components/shared/field/TextField.tsx
+++ b/apps/aki-erp/components/shared/field/TextField.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cx from 'classnames';
 import React from 'react';
 
 interface TextFieldProps
@@ -18,7 +18,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(function Te
       id={name}
       ref={ref}
       value={value || ''}
-      className={classNames('input input-bordered w-full', { 'input-error': errorMsg })}
+      className={cx('input input-bordered w-full', { 'input-error': errorMsg })}
     />
   );
 });

--- a/apps/aki-erp/components/shared/layout/SidebarSubmenu.tsx
+++ b/apps/aki-erp/components/shared/layout/SidebarSubmenu.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import classNames from 'classnames';
+import cx from 'classnames';
 import './SidebarSubmenu.scss';
 
 export interface SubMenuItem {
@@ -38,7 +38,7 @@ const SidebarSubmenu = ({ submenu, path, name, icon }: SidebarSubmenuProps) => {
   return (
     <details open={isExpanded}>
       <summary
-        className={classNames('flex py-0 pl-0', {
+        className={cx('flex py-0 pl-0', {
           'bg-base-200': pathname.startsWith(path || ''),
         })}
       >

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -208,7 +208,7 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
               <button
                 aria-label="export pdf file"

--- a/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect } from 'react';
 
-import cx from 'classnames';
 import dateFnsFormat from 'date-fns/format';
 import { useParams, useRouter } from 'next/navigation';
 import { showConfirm, showError, showSuccess } from 'utils/swalUtil';
@@ -214,9 +213,9 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full grid-cols-2 gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
-              <button
+              {/* <button
                 aria-label="export pdf file"
                 className={cx('btn btn-accent flex-1', {
                   'flex-nowrap whitespace-nowrap': exportOrderMutation.isLoading,
@@ -231,7 +230,7 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
                 ) : (
                   <>PDF 匯出</>
                 )}
-              </button>
+              </button> */}
             </div>
             <select
               className="select select-bordered"

--- a/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
+++ b/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
@@ -158,7 +158,7 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
         <div className="flex flex-col gap-4 md:flex-row">
           <form className="grid w-full gap-4">{fieldForm}</form>
 
-          <div className="flex flex-col justify-between gap-4 mt-8">
+          <div className="mt-8 flex flex-col justify-between gap-4">
             <div className="flex gap-2 md:flex-col">
               <button
                 aria-label="export pdf file"
@@ -173,7 +173,7 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
                     處理中 <span className="loading loading-ring loading-sm"></span>
                   </>
                 ) : (
-                  <>PDF 匯出</>
+                  <>表格匯出</>
                 )}
               </button>
             </div>

--- a/apps/aki-erp/data-access/apis/artworks.api.ts
+++ b/apps/aki-erp/data-access/apis/artworks.api.ts
@@ -110,10 +110,12 @@ export async function fetchArtworkList(
     .map(([key, value]) => {
       if (key === 'nationalities') return `countryCode=${value}`;
       if (key === 'artists') return `artistName=${value}`;
+      if (key === 'otherInfos') return `metadatas={"otherInfo":"{'${value}':'true'}"}`;
       if (key === 'storeTypes') return `metadatas={"storeType":"${value}"}`;
       if (key === 'salesTypes') return `metadatas={"salesType":"${value}"}`;
       if (key === 'assetsTypes') return `metadatas={"assetsType":"${value}"}`;
       if (key === 'serialNumbers') return `metadatas={"serialNumber":"${value}"}`;
+      if (key === 'agentGalleries') return `metadatas={"agentGalleries":"[{'name':'${value}'}]"}`;
       if (key === 'pageIndex') {
         const pageIndex = +(searchParams?.get('pageIndex') || 0);
         const pageSize = +(searchParams?.get('pageSize') || 50);

--- a/apps/aki-erp/data-access/hooks/index.ts
+++ b/apps/aki-erp/data-access/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './usefetchPartnerList';

--- a/apps/aki-erp/data-access/hooks/usefetchPartnerList.tsx
+++ b/apps/aki-erp/data-access/hooks/usefetchPartnerList.tsx
@@ -1,0 +1,24 @@
+import { fetchPartnerList } from '@data-access/apis/partners.api';
+import { PartnerType } from '@data-access/models';
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+
+export const usefetchPartnerList = <
+  TPartnerType extends PartnerType | undefined | null = undefined | null,
+>(
+  type: TPartnerType,
+) => {
+  const searchParams = useSearchParams();
+
+  return useQuery(
+    [type, searchParams.toString()],
+    () =>
+      fetchPartnerList({
+        type,
+        keyword: searchParams.get('keyword'),
+        pageIndex: +(searchParams.get('pageIndex') || 0),
+        pageSize: +(searchParams.get('pageSize') || 50),
+      }),
+    { keepPreviousData: true },
+  );
+};

--- a/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
+++ b/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
@@ -8,7 +8,9 @@ import {
   salesTypeOptionMap,
   storeTypeOptionMap,
 } from '@constants/artwork.constant';
+import { createOrUpdateArtworkDetail } from '@data-access/apis';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/20/solid';
+import { useMutation } from '@tanstack/react-query';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
 import { useTable } from '@utils/hooks';
 import { ArtworkDetail } from 'data-access/models';
@@ -27,6 +29,10 @@ const useArtworksOrderTable = ({
   isLoading,
 }: useArtworksOrderTableProps) => {
   const [selectedArtworks, setSelectedArtworks] = useState<ArtworkDetail[]>([]);
+
+  const mutation = useMutation({
+    mutationFn: (data: ArtworkDetail) => createOrUpdateArtworkDetail(data),
+  });
 
   const columns: ColumnDef<ArtworkDetail, any>[] = [
     {
@@ -129,6 +135,32 @@ const useArtworksOrderTable = ({
         if (cardboardBox) return '紙箱';
         if (woodenBox) return '木箱';
         return '無';
+      },
+    },
+    {
+      header: '在庫位置',
+      accessorKey: 'warehouseId',
+      cell: ({ row }) => {
+        const data = row.original;
+        const [value, setValue] = useState(data.warehouseId);
+
+        return (
+          <select
+            className="input w-[3rem] appearance-none p-0 text-center text-sm"
+            value={value}
+            onChange={(e) => {
+              data.warehouseId = +e.target.value;
+              setValue(+e.target.value);
+              mutation.mutate(data);
+            }}
+          >
+            <option value={0}>A</option>
+            <option value={1}>B</option>
+            <option value={2}>C</option>
+            <option value={3}>D</option>
+            <option value={4}>E</option>
+          </select>
+        );
       },
     },
     {


### PR DESCRIPTION
1. 針對 `藝術家` 與 `代理藝廊` 欄位綁定 `通運資訊` 裡面對應的 api，並且改成下拉式選單。
<img width="1398" alt="image" src="https://github.com/lightup-studio/AKI-ERP-Frontend/assets/31558373/14dc0149-902f-462c-9f62-26d9845b7eb9">

2. 統一將 `PDF 匯出` 改名為 `表格匯出`。
3. 若庫存狀態為 `在庫`，則藝術作品的 status 必須歸類為 `庫存`。
<img width="1239" alt="image" src="https://github.com/lightup-studio/AKI-ERP-Frontend/assets/31558373/c48b16a4-771c-4b1d-bca0-0beb73c6bc3d">

4. 若庫存狀態為 `非在庫`，則藝術作品的 status 必須歸類為 `非庫存`。
<img width="1254" alt="Screenshot 2024-03-06 at 11 26 28" src="https://github.com/lightup-studio/AKI-ERP-Frontend/assets/31558373/f7c3d4ac-4515-479f-a7ae-974d4c4d8e1e">

5. 只要庫存狀態不是 `在庫`，則 `在庫位置` 必須為 `空值`。
<img width="1245" alt="Screenshot 2024-03-06 at 11 28 20" src="https://github.com/lightup-studio/AKI-ERP-Frontend/assets/31558373/93dec765-7927-4e6e-998f-c8a8e5503d48">

6. 新增 `在庫位置` 欄位 
<img width="1472" alt="Screenshot 2024-03-06 at 11 29 38" src="https://github.com/lightup-studio/AKI-ERP-Frontend/assets/31558373/aa2513ce-a778-4bed-9a3a-0cb1cdaadadc">

7. 新增兩個搜尋功能（otherInfos & agentGalleries）
<img width="1265" alt="Screenshot 2024-03-06 at 11 31 49" src="https://github.com/lightup-studio/AKI-ERP-Frontend/assets/31558373/b51e9489-8f27-4d36-812d-b58a9f22fab0">




