### PR TITLE
Feature/orders

### DIFF
--- a/apps/aki-erp/app/(auth)/(admins)/admins/page.tsx
+++ b/apps/aki-erp/app/(auth)/(admins)/admins/page.tsx
@@ -182,7 +182,7 @@ const Admins = () => {
               table.setPageSize(Number(e.target.value));
             }}
           >
-            {[10, 30, 50, 80, 100].map((pageSize) => (
+            {[10, 20, 50, 100].map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 {pageSize} 筆
               </option>

--- a/apps/aki-erp/app/(auth)/(admins)/admins/page.tsx
+++ b/apps/aki-erp/app/(auth)/(admins)/admins/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { PAGE_SIZES } from '@constants/page.constant';
 import { createUser, deleteUser, fetchUsers } from '@data-access/apis';
 import { User } from '@data-access/models';
 import { PlusIcon } from '@heroicons/react/20/solid';
@@ -182,7 +183,7 @@ const Admins = () => {
               table.setPageSize(Number(e.target.value));
             }}
           >
-            {[10, 20, 50, 100].map((pageSize) => (
+            {PAGE_SIZES.map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 {pageSize} 筆
               </option>

--- a/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
@@ -31,7 +31,7 @@ const Artists = () => {
 
   const params = new URLSearchParams(searchParams);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 50);
+  const pageSize = +(params.get('pageSize') || 20);
 
   const [keyword, setKeyword] = useState(params.get('keyword'));
 
@@ -272,7 +272,7 @@ const Artists = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { UpdateArtistDialog } from '@components/artists';
 import SearchInput from '@components/shared/field/SearchField';
 import { formSchema } from '@constants/artists.formSchema';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '@constants/page.constant';
 import { usefetchPartnerList } from '@data-access/hooks';
 import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -31,7 +32,7 @@ const Artists = () => {
 
   const params = new URLSearchParams(searchParams);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 20);
+  const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
 
   const [keyword, setKeyword] = useState(params.get('keyword'));
 
@@ -272,7 +273,7 @@ const Artists = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/artists/page.tsx
@@ -129,7 +129,6 @@ const Artists = () => {
       zhName: '',
       enName: '',
       address: '',
-      telephone: '',
       metadata: {
         email: '',
       },
@@ -189,9 +188,7 @@ const Artists = () => {
               <label className="font-bold">電話</label>
               <div className="relative flex-1">
                 <input
-                  className={cx('input input-bordered w-full text-center', {
-                    'input-error': errors.telephone,
-                  })}
+                  className="input input-bordered w-full text-center"
                   placeholder="請輸入電話"
                   {...register('telephone')}
                 />

--- a/apps/aki-erp/app/(auth)/(information)/collector/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/collector/page.tsx
@@ -31,7 +31,7 @@ const Collector = () => {
 
   const params = new URLSearchParams(searchParams);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 50);
+  const pageSize = +(params.get('pageSize') || 20);
 
   const [keyword, setKeyword] = useState(params.get('keyword'));
 
@@ -297,7 +297,7 @@ const Collector = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(information)/collector/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/collector/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import UpdateCustomerDialog from '@components/collector/UpdateCustomerDialog';
 import SearchInput from '@components/shared/field/SearchField';
 import { formSchema } from '@constants/collector.formSchema';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '@constants/page.constant';
 import { usefetchPartnerList } from '@data-access/hooks';
 import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -31,7 +32,7 @@ const Collector = () => {
 
   const params = new URLSearchParams(searchParams);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 20);
+  const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
 
   const [keyword, setKeyword] = useState(params.get('keyword'));
 
@@ -297,7 +298,7 @@ const Collector = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(information)/company/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/company/page.tsx
@@ -31,7 +31,7 @@ const Company = () => {
 
   const params = new URLSearchParams(searchParams);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 50);
+  const pageSize = +(params.get('pageSize') || 20);
 
   const [keyword, setKeyword] = useState(searchParams.get('keyword'));
 
@@ -275,7 +275,7 @@ const Company = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(information)/company/page.tsx
+++ b/apps/aki-erp/app/(auth)/(information)/company/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import UpdateCompanyDialog from '@components/company/UpdateCompanyList';
 import SearchField from '@components/shared/field/SearchField';
 import { formSchema } from '@constants/company.formSchema';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '@constants/page.constant';
 import { usefetchPartnerList } from '@data-access/hooks';
 import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -31,7 +32,7 @@ const Company = () => {
 
   const params = new URLSearchParams(searchParams);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 20);
+  const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
 
   const [keyword, setKeyword] = useState(searchParams.get('keyword'));
 
@@ -275,7 +276,7 @@ const Company = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/lend/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/lend/orders/page.tsx
@@ -206,7 +206,7 @@ const LendOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/lend/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/lend/orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteLendOrderId,
   exportLendOrdersByIds,
@@ -206,7 +207,7 @@ const LendOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/lend/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/lend/return-orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteLendReturnOrderId,
   exportLendReturnOrdersByIds,
@@ -206,7 +207,7 @@ const LendReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/lend/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/lend/return-orders/page.tsx
@@ -206,7 +206,7 @@ const LendReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/purchase/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/purchase/orders/page.tsx
@@ -185,7 +185,7 @@ const PurchaseOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/purchase/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/purchase/orders/page.tsx
@@ -9,6 +9,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deletePurchaseOrderId,
   exportPurchaseOrdersByIds,
@@ -185,7 +186,7 @@ const PurchaseOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/purchase/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/purchase/return-orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deletePurchaseReturnOrderId,
   exportPurchaseReturnOrdersByIds,
@@ -206,7 +207,7 @@ const PurchaseReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/purchase/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/purchase/return-orders/page.tsx
@@ -206,7 +206,7 @@ const PurchaseReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/repair/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/repair/orders/page.tsx
@@ -207,7 +207,7 @@ const RepairOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/repair/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/repair/orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteRepairOrderId,
   exportRepairOrdersByIds,
@@ -207,7 +208,7 @@ const RepairOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/repair/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/repair/return-orders/page.tsx
@@ -209,7 +209,7 @@ const RepairReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/repair/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/repair/return-orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteRepairReturnOrderId,
   exportRepairReturnOrdersByIds,
@@ -209,7 +210,7 @@ const RepairReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/shipment/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/shipment/orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteSalesOrderId,
   exportSalesOrdersByIds,
@@ -207,7 +208,7 @@ const ShipmentOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/shipment/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/shipment/orders/page.tsx
@@ -207,7 +207,7 @@ const ShipmentOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/shipment/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/shipment/return-orders/page.tsx
@@ -209,7 +209,7 @@ const ShipmentReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/shipment/return-orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/shipment/return-orders/page.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteSalesReturnOrderId,
   exportSalesReturnOrdersByIds,
@@ -209,7 +210,7 @@ const ShipmentReturnOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/transfer/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/transfer/orders/page.tsx
@@ -181,7 +181,7 @@ const TransferOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/app/(auth)/(procurement)/transfer/orders/page.tsx
+++ b/apps/aki-erp/app/(auth)/(procurement)/transfer/orders/page.tsx
@@ -9,6 +9,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 
 import { ArtworksBatchUpdateDialog, ArtworksPreviewBtn } from '@components/artworks';
 import { SearchField } from '@components/shared/field';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   deleteTransferOrderId,
   exportTransferOrdersByIds,
@@ -181,7 +182,7 @@ const TransferOrders = () => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/artworks/ArtworksBatchUpdateDialog.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksBatchUpdateDialog.tsx
@@ -41,14 +41,12 @@ const ArtworksBatchUpdateDialog: React.FC<ArtworksBatchUpdateDialogProsp> = ({
         ),
       );
     },
-    onSuccess: async () => {
-      await showSuccess('更新成功！');
-      onClose?.();
-    },
-    onError: async () => {
-      await showError('更新失敗！');
-    },
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   useEffect(() => {
     const mainElement = document.querySelector('main');

--- a/apps/aki-erp/components/artworks/ArtworksBatchUpdateDialog.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksBatchUpdateDialog.tsx
@@ -46,7 +46,7 @@ const ArtworksBatchUpdateDialog: React.FC<ArtworksBatchUpdateDialogProsp> = ({
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   useEffect(() => {
     const mainElement = document.querySelector('main');

--- a/apps/aki-erp/components/artworks/ArtworksBatchUpdateTable.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksBatchUpdateTable.tsx
@@ -44,7 +44,7 @@ const ArtworksBatchUpdateTable: React.FC<ArtworksBatchUpdateTableProps> = ({
       ),
     },
     {
-      header: '在庫位置',
+      header: '庫存位置',
       cell: ({ row }) => {
         return (
           <div className="flex items-center gap-2">

--- a/apps/aki-erp/components/artworks/ArtworksList.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksList.tsx
@@ -3,12 +3,7 @@
 import { useMemo } from 'react';
 
 import SearchField from '@components/shared/field/SearchField';
-import {
-  StoreType,
-  assetsTypeOptions,
-  salesTypeOptions,
-  storeTypeOptionMap,
-} from '@constants/artwork.constant';
+import { StoreType, assetsTypeOptions, salesTypeOptions } from '@constants/artwork.constant';
 import { deleteArtworks, patchArtworks } from '@data-access/apis/artworks.api';
 import { ArtworkDetail, Status } from '@data-access/models';
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components';
@@ -21,6 +16,7 @@ import { CellContext, ColumnDef } from '@tanstack/react-table';
 
 import { useArtworkSearches, useArtworkSelectedList } from '@utils/hooks/useArtworkSearches';
 import useArtworksTable, { selectColumn } from '@utils/hooks/useArtworksTable';
+import { showStoreTypeText } from '@utils/showStoreTypeText';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ArtworksTitleProps } from './ArtworksTitle';
@@ -154,8 +150,8 @@ const ArtworksList = ({ type }: ArtworksListProps) => {
       header: '庫存狀態',
       accessorKey: 'metadata',
       cell: ({ cell }: CellContext<ArtworkDetail, ArtworkDetail['metadata']>) => {
-        const storeTypeId = cell.getValue()?.storeType ?? 'inStock';
-        return storeTypeOptionMap[storeTypeId].label;
+        const storeTypeId = cell.getValue()?.storeType;
+        return showStoreTypeText(storeTypeId);
       },
     },
     {

--- a/apps/aki-erp/components/artworks/ArtworksList.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksList.tsx
@@ -3,7 +3,12 @@
 import { useMemo } from 'react';
 
 import SearchField from '@components/shared/field/SearchField';
-import { StoreType, assetsTypeOptions, salesTypeOptions } from '@constants/artwork.constant';
+import {
+  StoreType,
+  assetsTypeOptions,
+  salesTypeOptions,
+  warehouseMap,
+} from '@constants/artwork.constant';
 import { deleteArtworks, patchArtworks } from '@data-access/apis/artworks.api';
 import { ArtworkDetail, Status } from '@data-access/models';
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components';
@@ -195,6 +200,14 @@ const ArtworksList = ({ type }: ArtworksListProps) => {
           },
         });
       },
+    },
+    {
+      id: 'warehouseId',
+      header: '庫存位置',
+      accessorKey: 'warehouseId',
+      cell: ({ row }) => (
+        <>{row.original.warehouseId ? warehouseMap[row.original.warehouseId] : ''}</>
+      ),
     },
   ];
 

--- a/apps/aki-erp/components/artworks/ArtworksList.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksList.tsx
@@ -19,6 +19,7 @@ import TrashIcon from '@heroicons/react/24/solid/TrashIcon';
 import { useMutation } from '@tanstack/react-query';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
 
+import { PAGE_SIZES } from '@constants/page.constant';
 import { useArtworkSearches, useArtworkSelectedList } from '@utils/hooks/useArtworkSearches';
 import useArtworksTable, { selectColumn } from '@utils/hooks/useArtworksTable';
 import { showStoreTypeText } from '@utils/showStoreTypeText';
@@ -281,7 +282,7 @@ const ArtworksList = ({ type }: ArtworksListProps) => {
               table.setPageSize(Number(e.target.value));
             }}
           >
-            {[10, 20, 50, 100].map((pageSize) => (
+            {PAGE_SIZES.map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 {pageSize} 筆
               </option>

--- a/apps/aki-erp/components/artworks/ArtworksList.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksList.tsx
@@ -145,6 +145,11 @@ const ArtworksList = ({ type }: ArtworksListProps) => {
       },
     },
     {
+      id: 'edition',
+      header: '版次',
+      accessorKey: 'metadata.edition',
+    },
+    {
       id: 'storeType',
       header: '庫存狀態',
       accessorKey: 'metadata',

--- a/apps/aki-erp/components/artworks/ArtworksList.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksList.tsx
@@ -267,7 +267,7 @@ const ArtworksList = ({ type }: ArtworksListProps) => {
               table.setPageSize(Number(e.target.value));
             }}
           >
-            {[10, 30, 50, 80, 100].map((pageSize) => (
+            {[10, 20, 50, 100].map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 {pageSize} 筆
               </option>

--- a/apps/aki-erp/components/artworks/ArtworksList.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksList.tsx
@@ -119,7 +119,7 @@ const ArtworksList = ({ type }: ArtworksListProps) => {
       cell: ({ cell }: CellContext<ArtworkDetail, ArtworkDetail['metadata']>) => {
         const { length, width, height } = cell.getValue<ArtworkDetail['metadata']>() || {};
         return length || width || height
-          ? `${length && `長 ${length} cm`} ${width && `x 寬 ${width} cm`} ${
+          ? `${length && `長 ${length}`} ${width && `x 寬 ${width}`} ${
               height && `x 高 ${height} cm`
             }`
           : '無';

--- a/apps/aki-erp/components/artworks/ArtworksSelector.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksSelector.tsx
@@ -255,7 +255,7 @@ const ArtworksSelector = ({
                   table.setPageSize(Number(e.target.value));
                 }}
               >
-                {[10, 30, 50, 80, 100].map((pageSize) => (
+                {[10, 20, 50, 100].map((pageSize) => (
                   <option key={pageSize} value={pageSize}>
                     {pageSize} 筆
                   </option>

--- a/apps/aki-erp/components/artworks/ArtworksSelector.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksSelector.tsx
@@ -117,7 +117,7 @@ const ArtworksSelector = ({
       cell: ({ cell }: CellContext<ArtworkDetail, ArtworkDetail['metadata']>) => {
         const { length, width, height } = cell.getValue<ArtworkDetail['metadata']>() || {};
         return length || width || height
-          ? `${length && `長 ${length} cm`} ${width && `x 寬 ${width} cm`} ${
+          ? `${length && `長 ${length}`} ${width && `x 寬 ${width}`} ${
               height && `x 高 ${height} cm`
             }`
           : '無';

--- a/apps/aki-erp/components/artworks/ArtworksSelector.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksSelector.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 
 import SearchInput from '@components/shared/field/SearchField';
 import { assetsTypeOptions, salesTypeOptions } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import { CheckIcon, PencilSquareIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
 import { useArtworkSearches, useArtworkSelectedList } from '@utils/hooks/useArtworkSearches';
@@ -252,7 +253,7 @@ const ArtworksSelector = ({
                   table.setPageSize(Number(e.target.value));
                 }}
               >
-                {[10, 20, 50, 100].map((pageSize) => (
+                {PAGE_SIZES.map((pageSize) => (
                   <option key={pageSize} value={pageSize}>
                     {pageSize} 筆
                   </option>

--- a/apps/aki-erp/components/artworks/ArtworksSelector.tsx
+++ b/apps/aki-erp/components/artworks/ArtworksSelector.tsx
@@ -3,15 +3,12 @@
 import { useEffect } from 'react';
 
 import SearchInput from '@components/shared/field/SearchField';
-import {
-  assetsTypeOptions,
-  salesTypeOptions,
-  storeTypeOptionMap,
-} from '@constants/artwork.constant';
+import { assetsTypeOptions, salesTypeOptions } from '@constants/artwork.constant';
 import { CheckIcon, PencilSquareIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
 import { useArtworkSearches, useArtworkSelectedList } from '@utils/hooks/useArtworkSearches';
 import useArtworksTable, { selectColumn } from '@utils/hooks/useArtworksTable';
+import { showStoreTypeText } from '@utils/showStoreTypeText';
 import cx from 'classnames';
 import { ArtworkDetail, Status } from 'data-access/models';
 import Link from 'next/link';
@@ -147,8 +144,8 @@ const ArtworksSelector = ({
       header: '庫存狀態',
       accessorKey: 'metadata',
       cell: ({ cell }: CellContext<ArtworkDetail, ArtworkDetail['metadata']>) => {
-        const storeTypeId = cell.getValue()?.storeType ?? 'inStock';
-        return storeTypeOptionMap[storeTypeId].label;
+        const storeTypeId = cell.getValue()?.storeType;
+        return showStoreTypeText(storeTypeId);
       },
     },
     {

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createLendOrder,
   exportLendOrderById,
@@ -264,7 +265,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -149,7 +149,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
     setValue('metadata', data.metadata);
   }, [data]);
 
-  const { table, tableBlock } = useArtworksOrderTable({
+  const { table, tableBlock, selectedRows, selectedRowsCount } = useArtworksOrderTable({
     artworks: data?.artworks,
     disabled,
     isLoading,
@@ -225,6 +225,13 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
     await exportOrderMutation.mutateAsync(+id);
   };
 
+  const handleAddOrders = () => {
+    const query = new URLSearchParams();
+    selectedRows.map((artwork) => query.append('artworkId', artwork.id.toString()));
+
+    router.push(`/lend/return-orders/add?${query.toString()}`);
+  };
+
   return (
     <>
       <div className="card bg-base-100 min-h-full w-full p-6 shadow-xl">
@@ -269,6 +276,17 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
         <div className="divider my-2"></div>
 
         <div className="bg-base-100 h-full w-full text-center">
+          <div className="flex items-center gap-2">
+            <span>已選擇 {selectedRowsCount} 筆</span>
+            <button
+              className="btn btn-accent"
+              onClick={handleAddOrders}
+              disabled={selectedRowsCount === 0}
+            >
+              加入借出歸還單
+            </button>
+          </div>
+
           {tableBlock}
 
           {!disabled ? (

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -192,9 +192,12 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateLendOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -257,7 +257,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -14,6 +14,7 @@ import {
   exportLendOrderById,
   fetchLendOrderId,
   patchArtworksBatchId,
+  updateLendOrder,
 } from '@data-access/apis';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -34,7 +35,10 @@ type FormData = {
     phone?: string;
     address?: string;
   };
-  memo?: string;
+  memo?: any;
+  metadata?: {
+    carrier?: string;
+  };
 };
 
 const schema = yup.object().shape({
@@ -49,7 +53,10 @@ const schema = yup.object().shape({
     phone: yup.string().required('必填項目'),
     address: yup.string().required('必填項目'),
   }),
-  memo: yup.string(),
+  memo: yup.string().nullable(),
+  metadata: yup.object({
+    carrier: yup.string(),
+  }),
 });
 
 interface LendOrderDetailProps {
@@ -109,6 +116,12 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
       label: '備註',
       disabled: disabled,
     },
+    {
+      type: 'TEXT',
+      name: 'metadata.carrier',
+      label: '承運人',
+      disabled: disabled,
+    },
   ];
 
   const { fieldForm, setValue, handleSubmit } = useFieldForm<FormData>({
@@ -133,6 +146,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
     setValue('receiverInformation', data.receiverInformation);
     setValue('contactPersonInformation', data.contactPersonInformation);
     setValue('memo', data.memo);
+    setValue('metadata', data.metadata);
   }, [data]);
 
   const { table, tableBlock } = useArtworksOrderTable({
@@ -153,6 +167,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
           receiverInformation: formData.receiverInformation,
           contactPersonInformation: formData.contactPersonInformation,
           memo: formData.memo,
+          metadata: formData.metadata,
         }),
         patchArtworksBatchId({
           idList: artworkIdList,
@@ -174,6 +189,12 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: (formData: FormData) => updateLendOrder(formData),
+    onSuccess: async () => await showSuccess('更新成功！'),
+    onError: async () => await showError('更新失敗！'),
+  });
+
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({
       title: '確定新增借出單？',
@@ -182,6 +203,10 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
 
     if (!isConfirmed) return;
     await createMutation.mutateAsync(formData);
+  };
+
+  const onUpdate = async (formData: FormData) => {
+    await updateMutation.mutateAsync(formData);
   };
 
   const exportOrderMutation = useMutation({
@@ -246,7 +271,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
+          {!disabled ? (
             <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
@@ -261,6 +286,12 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
                 onClick={() => router.back()}
               >
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
+              </button>
+            </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
               </button>
             </div>
           )}

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -280,16 +280,18 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
         <div className="divider my-2"></div>
 
         <div className="bg-base-100 h-full w-full text-center">
-          <div className="flex items-center gap-2">
-            <span>已選擇 {selectedRowsCount} 筆</span>
-            <button
-              className="btn btn-accent"
-              onClick={handleAddOrders}
-              disabled={selectedRowsCount === 0}
-            >
-              加入借出歸還單
-            </button>
-          </div>
+          {disabled && (
+            <div className="flex items-center gap-2">
+              <span>已選擇 {selectedRowsCount} 筆</span>
+              <button
+                className="btn btn-accent"
+                onClick={handleAddOrders}
+                disabled={selectedRowsCount === 0}
+              >
+                加入借出歸還單
+              </button>
+            </div>
+          )}
 
           {tableBlock}
 

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -36,7 +36,7 @@ type FormData = {
     phone?: string;
     address?: string;
   };
-  memo?: any;
+  memo?: string;
   metadata?: {
     carrier?: string;
   };
@@ -54,7 +54,7 @@ const schema = yup.object().shape({
     phone: yup.string().required('必填項目'),
     address: yup.string().required('必填項目'),
   }),
-  memo: yup.string().nullable(),
+  memo: yup.string(),
   metadata: yup.object({
     carrier: yup.string(),
   }),
@@ -146,7 +146,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
     setValue('lendDepartment', data.lendDepartment);
     setValue('receiverInformation', data.receiverInformation);
     setValue('contactPersonInformation', data.contactPersonInformation);
-    setValue('memo', data.memo);
+    setValue('memo', data.memo || '');
     setValue('metadata', data.metadata);
   }, [data]);
 

--- a/apps/aki-erp/components/lend/LendOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendOrderDetail.tsx
@@ -197,7 +197,7 @@ const LendOrderDetail: React.FC<LendOrderDetailProps> = ({ disabled }) => {
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
@@ -261,7 +261,7 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
@@ -38,7 +38,7 @@ type FormData = {
     phone?: string;
     address?: string;
   };
-  memo?: any;
+  memo?: string;
   metadata?: {
     carrier?: string;
   };
@@ -56,7 +56,7 @@ const schema = yup.object().shape({
     phone: yup.string().required('必填項目'),
     address: yup.string().required('必填項目'),
   }),
-  memo: yup.string().nullable(),
+  memo: yup.string(),
   metadata: yup.object({
     carrier: yup.string(),
   }),
@@ -155,7 +155,7 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
     setValue('lendDepartment', data.lendDepartment);
     setValue('returnerInformation', data.returnerInformation);
     setValue('contactPersonInformation', data.contactPersonInformation);
-    setValue('memo', data.memo);
+    setValue('memo', data.memo || '');
     setValue('metadata', data.metadata);
   }, [data]);
 

--- a/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
@@ -208,9 +208,12 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateLendReturnOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createLendReturnOrder,
   exportLendReturnOrderById,
@@ -273,7 +274,7 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/lend/LendReturnOrderDetail.tsx
@@ -213,7 +213,7 @@ const LendReturnOrderDetail: React.FC<LendReturnOrderDetailProps> = ({ disabled 
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -150,10 +150,7 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
           salesCompany: formData.salesCompany,
           purchaseTime: formData.purchaseTime,
           salesInformation: formData.salesInformation,
-          metadata: {
-            memo: formData.metadata?.memo,
-            carrier: formData.metadata?.carrier,
-          },
+          metadata: formData.metadata,
         }),
         patchArtworksBatchId({
           idList: artworkIdList,
@@ -257,8 +254,8 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
-            <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
+          {!disabled ? (
+            <div className="bg-base-100 my-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
                 isLoading={createMutation.isLoading}
@@ -274,13 +271,13 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
               </button>
             </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
+              </button>
+            </div>
           )}
-
-          <div className="bg-base-100 my-4">
-            <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
-              修改
-            </button>
-          </div>
         </div>
       </div>
     </>

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -180,7 +180,7 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createPurchaseOrder,
   exportPurchaseOrderById,
@@ -247,7 +248,7 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -263,16 +263,18 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
         <div className="divider my-2"></div>
 
         <div className="bg-base-100 h-full w-full text-center">
-          <div className="flex items-center gap-2">
-            <span>已選擇 {selectedRowsCount} 筆</span>
-            <button
-              className="btn btn-accent"
-              onClick={handleAddOrders}
-              disabled={selectedRowsCount === 0}
-            >
-              加入進貨歸還單
-            </button>
-          </div>
+          {disabled && (
+            <div className="flex items-center gap-2">
+              <span>已選擇 {selectedRowsCount} 筆</span>
+              <button
+                className="btn btn-accent"
+                onClick={handleAddOrders}
+                disabled={selectedRowsCount === 0}
+              >
+                加入進貨歸還單
+              </button>
+            </div>
+          )}
 
           {tableBlock}
 

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -134,7 +134,7 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
     setValue('metadata', data.metadata);
   }, [data]);
 
-  const { table, tableBlock } = useArtworksOrderTable({
+  const { table, tableBlock, selectedRows, selectedRowsCount } = useArtworksOrderTable({
     artworks: [...draftArtworks, ...(data?.artworks || [])],
     disabled,
     isLoading,
@@ -208,6 +208,13 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
     await exportOrderMutation.mutateAsync(+id);
   };
 
+  const handleAddOrders = () => {
+    const query = new URLSearchParams();
+    selectedRows.map((artwork) => query.append('artworkId', artwork.id.toString()));
+
+    router.push(`/purchase/return-orders/add?${query.toString()}`);
+  };
+
   return (
     <>
       <div className="card bg-base-100 min-h-full w-full p-6 shadow-xl">
@@ -252,6 +259,17 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
         <div className="divider my-2"></div>
 
         <div className="bg-base-100 h-full w-full text-center">
+          <div className="flex items-center gap-2">
+            <span>已選擇 {selectedRowsCount} 筆</span>
+            <button
+              className="btn btn-accent"
+              onClick={handleAddOrders}
+              disabled={selectedRowsCount === 0}
+            >
+              加入進貨歸還單
+            </button>
+          </div>
+
           {tableBlock}
 
           {!disabled ? (

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -240,7 +240,7 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseOrderDetail.tsx
@@ -175,9 +175,12 @@ const PurchaseOrderDetail: React.FC<PurchaseOrderDetailProps> = ({ disabled }) =
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updatePurchaseOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createPurchaseReturnOrder,
   exportPurchaseReturnOrderById,
@@ -250,7 +251,7 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -190,7 +190,7 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -74,7 +74,7 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
     {
       type: 'DATE',
       name: 'purchaseReturnTime',
-      label: '進貨日期',
+      label: '退還日期',
       disabled: disabled,
     },
     {

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -185,9 +185,12 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updatePurchaseReturnOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -238,7 +238,7 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/purchase/PurchaseReturnOrderDetail.tsx
@@ -14,6 +14,7 @@ import {
   exportPurchaseReturnOrderById,
   fetchPurchaseReturnOrderId,
   patchArtworksBatchId,
+  updatePurchaseReturnOrder,
 } from '@data-access/apis';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -169,6 +170,12 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: (formData: FormData) => updatePurchaseReturnOrder(formData),
+    onSuccess: async () => await showSuccess('更新成功！'),
+    onError: async () => await showError('更新失敗！'),
+  });
+
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({
       title: '確定新增進貨退還單？',
@@ -177,6 +184,10 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
 
     if (!isConfirmed) return;
     await createMutation.mutateAsync(formData);
+  };
+
+  const onUpdate = async (formData: FormData) => {
+    await updateMutation.mutateAsync(formData);
   };
 
   const exportOrderMutation = useMutation({
@@ -241,7 +252,7 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
+          {!disabled ? (
             <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
@@ -256,6 +267,12 @@ const PurchaseReturnOrderDetail: React.FC<PurchaseReturnOrderDetailProps> = ({ d
                 onClick={() => router.back()}
               >
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
+              </button>
+            </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
               </button>
             </div>
           )}

--- a/apps/aki-erp/components/purchase/__test__/PurchaseOrderDetail.spec.tsx
+++ b/apps/aki-erp/components/purchase/__test__/PurchaseOrderDetail.spec.tsx
@@ -38,12 +38,14 @@ describe('Purchase order', () => {
     render(await act(() => <PurchaseOrderDetail />), { wrapper });
 
     const labels = screen.getAllByRole('label');
-    expect(labels).toHaveLength(4);
+    expect(labels).toHaveLength(6);
 
     await waitFor(async () => expect(await screen.findByText('進貨單位')).toBeInTheDocument());
     await waitFor(async () => expect(await screen.findByText('進貨日期')).toBeInTheDocument());
     await waitFor(async () => expect(await screen.findByText('聯絡人')).toBeInTheDocument());
     await waitFor(async () => expect(await screen.findByText('聯絡人電話')).toBeInTheDocument());
+    await waitFor(async () => expect(await screen.findByText('備註')).toBeInTheDocument());
+    await waitFor(async () => expect(await screen.findByText('承運人')).toBeInTheDocument());
   });
 
   it('should render data', async () => {

--- a/apps/aki-erp/components/purchase/__test__/PurchaseReturnOrderDetail.spec.tsx
+++ b/apps/aki-erp/components/purchase/__test__/PurchaseReturnOrderDetail.spec.tsx
@@ -42,7 +42,7 @@ describe('Purchase return order', () => {
     expect(labels).toHaveLength(7);
 
     expect(screen.getByText('進貨退還單位')).toBeInTheDocument();
-    expect(screen.getByText('進貨日期')).toBeInTheDocument();
+    expect(screen.getByText('退還日期')).toBeInTheDocument();
     expect(screen.getByText('聯絡人')).toBeInTheDocument();
     expect(screen.getByText('聯絡人電話')).toBeInTheDocument();
     expect(screen.getByText('收件人')).toBeInTheDocument();

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -36,7 +36,7 @@ type FormData = {
     phone?: string;
     address?: string;
   };
-  memo?: any;
+  memo?: string;
   metadata?: {
     carrier?: string;
   };
@@ -54,7 +54,7 @@ const schema = yup.object().shape({
     phone: yup.string().required('必填項目'),
     address: yup.string().required('必填項目'),
   }),
-  memo: yup.string().nullable(),
+  memo: yup.string(),
   metadata: yup.object({
     carrier: yup.string(),
   }),
@@ -146,7 +146,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
     setValue('contactPersonInformation', data.contactPersonInformation);
     setValue('receiverInformation', data.receiverInformation);
     setValue('repairDepartment', data.repairDepartment);
-    setValue('memo', data.memo);
+    setValue('memo', data.memo || '');
     setValue('metadata', data.metadata);
   }, [data]);
 

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -281,16 +281,18 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
         <div className="divider my-2"></div>
 
         <div className="bg-base-100 h-full w-full text-center">
-          <div className="flex items-center gap-2">
-            <span>已選擇 {selectedRowsCount} 筆</span>
-            <button
-              className="btn btn-accent"
-              onClick={handleAddOrders}
-              disabled={selectedRowsCount === 0}
-            >
-              加入維修歸還單
-            </button>
-          </div>
+          {disabled && (
+            <div className="flex items-center gap-2">
+              <span>已選擇 {selectedRowsCount} 筆</span>
+              <button
+                className="btn btn-accent"
+                onClick={handleAddOrders}
+                disabled={selectedRowsCount === 0}
+              >
+                加入維修歸還單
+              </button>
+            </div>
+          )}
 
           {tableBlock}
 

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -14,6 +14,7 @@ import {
   exportRepairOrderById,
   fetchRepairOrderId,
   patchArtworksBatchId,
+  updateRepairOrder,
 } from '@data-access/apis';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -34,7 +35,10 @@ type FormData = {
     phone?: string;
     address?: string;
   };
-  memo?: string;
+  memo?: any;
+  metadata?: {
+    carrier?: string;
+  };
 };
 
 const schema = yup.object().shape({
@@ -49,7 +53,10 @@ const schema = yup.object().shape({
     phone: yup.string().required('必填項目'),
     address: yup.string().required('必填項目'),
   }),
-  memo: yup.string(),
+  memo: yup.string().nullable(),
+  metadata: yup.object({
+    carrier: yup.string(),
+  }),
 });
 
 interface RepairOrderDetailProps {
@@ -109,6 +116,12 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
       label: '備註',
       disabled: disabled,
     },
+    {
+      type: 'TEXT',
+      name: 'metadata.carrier',
+      label: '承運人',
+      disabled: disabled,
+    },
   ];
 
   const { fieldForm, setValue, handleSubmit } = useFieldForm<FormData>({
@@ -133,6 +146,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
     setValue('receiverInformation', data.receiverInformation);
     setValue('repairDepartment', data.repairDepartment);
     setValue('memo', data.memo);
+    setValue('metadata', data.metadata);
   }, [data]);
 
   const { table, tableBlock } = useArtworksOrderTable({
@@ -153,6 +167,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
           receiverInformation: formData.receiverInformation,
           contactPersonInformation: formData.contactPersonInformation,
           memo: formData.memo,
+          metadata: formData.metadata,
         }),
         patchArtworksBatchId({
           idList: artworkIdList,
@@ -175,6 +190,12 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: (formData: FormData) => updateRepairOrder(formData),
+    onSuccess: async () => await showSuccess('更新成功！'),
+    onError: async () => await showError('更新失敗！'),
+  });
+
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({
       title: '確定新增維修單？',
@@ -183,6 +204,10 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
 
     if (!isConfirmed) return;
     await createMutation.mutateAsync(formData);
+  };
+
+  const onUpdate = async (formData: FormData) => {
+    await updateMutation.mutateAsync(formData);
   };
 
   const exportOrderMutation = useMutation({
@@ -247,8 +272,8 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
-            <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
+          {!disabled ? (
+            <div className="bg-base-100 my-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
                 isLoading={createMutation.isLoading}
@@ -262,6 +287,12 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
                 onClick={() => router.back()}
               >
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
+              </button>
+            </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
               </button>
             </div>
           )}

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -258,7 +258,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -149,7 +149,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
     setValue('metadata', data.metadata);
   }, [data]);
 
-  const { table, tableBlock } = useArtworksOrderTable({
+  const { table, tableBlock, selectedRows, selectedRowsCount } = useArtworksOrderTable({
     artworks: data?.artworks,
     disabled,
     isLoading,
@@ -226,6 +226,13 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
     await exportOrderMutation.mutateAsync(+id);
   };
 
+  const handleAddOrders = () => {
+    const query = new URLSearchParams();
+    selectedRows.map((artwork) => query.append('artworkId', artwork.id.toString()));
+
+    router.push(`/repair/return-orders/add?${query.toString()}`);
+  };
+
   return (
     <>
       <div className="card bg-base-100 min-h-full w-full p-6 shadow-xl">
@@ -270,6 +277,17 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
         <div className="divider my-2"></div>
 
         <div className="bg-base-100 h-full w-full text-center">
+          <div className="flex items-center gap-2">
+            <span>已選擇 {selectedRowsCount} 筆</span>
+            <button
+              className="btn btn-accent"
+              onClick={handleAddOrders}
+              disabled={selectedRowsCount === 0}
+            >
+              加入維修歸還單
+            </button>
+          </div>
+
           {tableBlock}
 
           {!disabled ? (

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -198,7 +198,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createRepairOrder,
   exportRepairOrderById,
@@ -265,7 +266,7 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/repair/RepairOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairOrderDetail.tsx
@@ -193,9 +193,12 @@ const RepairOrderDetail: React.FC<RepairOrderDetailProps> = ({ disabled }) => {
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateRepairOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createRepairReturnOrder,
   exportRepairReturnOrderById,
@@ -260,7 +261,7 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
@@ -248,7 +248,7 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
@@ -200,7 +200,7 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
@@ -195,9 +195,12 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateRepairReturnOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/repair/RepairReturnOrderDetail.tsx
@@ -14,6 +14,7 @@ import {
   exportRepairReturnOrderById,
   fetchRepairReturnOrderId,
   patchArtworksBatchId,
+  updateRepairReturnOrder,
 } from '@data-access/apis';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -179,6 +180,12 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: (formData: FormData) => updateRepairReturnOrder(formData),
+    onSuccess: async () => await showSuccess('更新成功！'),
+    onError: async () => await showError('更新失敗！'),
+  });
+
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({
       title: '確定新增維修歸還單？',
@@ -187,6 +194,10 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
 
     if (!isConfirmed) return;
     await createMutation.mutateAsync(formData);
+  };
+
+  const onUpdate = async (formData: FormData) => {
+    await updateMutation.mutateAsync(formData);
   };
 
   const exportOrderMutation = useMutation({
@@ -251,7 +262,7 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
+          {!disabled ? (
             <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
@@ -266,6 +277,12 @@ const RepairReturnOrderDetail: React.FC<RepairReturnOrderDetailProps> = ({ disab
                 onClick={() => router.back()}
               >
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
+              </button>
+            </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
               </button>
             </div>
           )}

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -195,9 +195,12 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateSalesOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -200,7 +200,7 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -10,6 +10,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createSalesOrder,
   exportSalesOrderById,
@@ -260,7 +261,7 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -175,6 +175,7 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
           properties: {
             metadata: {
               storeType: StoreType.SHIPPING,
+              salesType: 'sold',
               shippingDepartment: formData.shippingDepartment,
               returnedShippingDepartment: undefined,
             },

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -259,7 +259,7 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentOrderDetail.tsx
@@ -37,7 +37,7 @@ type FormData = {
     phone?: string;
     address?: string;
   };
-  memo?: any;
+  memo?: string;
   metadata?: {
     carrier?: string;
   };
@@ -55,7 +55,7 @@ const schema = yup.object().shape({
     phone: yup.string().required('必填項目'),
     address: yup.string().required('必填項目'),
   }),
-  memo: yup.string().nullable(),
+  memo: yup.string(),
   metadata: yup.object({
     carrier: yup.string(),
   }),
@@ -147,7 +147,7 @@ const ShipmentOrderDetail: React.FC<ShipmentOrderDetailProps> = ({ disabled }) =
     setValue('contactPersonInformation', data.contactPersonInformation);
     setValue('receiverInformation', data.receiverInformation);
     setValue('shippingDepartment', data.shippingDepartment);
-    setValue('memo', data.memo);
+    setValue('memo', data.memo || '');
     setValue('metadata', data.metadata);
   }, [data]);
 

--- a/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
@@ -190,7 +190,7 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
@@ -185,9 +185,12 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateSalesReturnOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
@@ -250,7 +250,7 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createSalesReturnOrder,
   exportSalesReturnOrderById,
@@ -250,7 +251,7 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
+++ b/apps/aki-erp/components/shipment/ShipmentReturnOrderDetail.tsx
@@ -14,6 +14,7 @@ import {
   exportSalesReturnOrderById,
   fetchSalesReturnOrderId,
   patchArtworksBatchId,
+  updateSalesReturnOrder,
 } from '@data-access/apis';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -181,6 +182,12 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: (formData: FormData) => updateSalesReturnOrder(formData),
+    onSuccess: async () => await showSuccess('更新成功！'),
+    onError: async () => await showError('更新失敗！'),
+  });
+
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({
       title: '確定新增出貨單？',
@@ -189,6 +196,10 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
 
     if (!isConfirmed) return;
     await createMutation.mutateAsync(formData);
+  };
+
+  const onUpdate = async (formData: FormData) => {
+    await updateMutation.mutateAsync(formData);
   };
 
   const exportOrderMutation = useMutation({
@@ -253,7 +264,7 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
+          {!disabled ? (
             <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
@@ -268,6 +279,12 @@ const ShipmentReturnOrderDetail: React.FC<ShipmentReturnOrderDetailProps> = ({ d
                 onClick={() => router.back()}
               >
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
+              </button>
+            </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
               </button>
             </div>
           )}

--- a/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
+++ b/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
@@ -130,9 +130,12 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
 
   const updateMutation = useMutation({
     mutationFn: (formData: FormData) => updateTransferOrder(formData),
-    onSuccess: async () => await showSuccess('更新成功！'),
-    onError: async () => await showError('更新失敗！'),
   });
+
+  useEffect(() => {
+    if (updateMutation.isSuccess) showSuccess('更新成功！');
+    if (updateMutation.isError) showError('更新失敗！');
+  }, [updateMutation.isSuccess]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
+++ b/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
@@ -195,7 +195,7 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 30, 50, 80, 100].map((pageSize) => (
+              {[10, 20, 50, 100].map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
+++ b/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
@@ -15,6 +15,7 @@ import {
   exportTransferOrderById,
   fetchTransferOrderId,
   patchArtworksBatchId,
+  updateTransferOrder,
 } from '@data-access/apis';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -126,6 +127,12 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: (formData: FormData) => updateTransferOrder(formData),
+    onSuccess: async () => await showSuccess('更新成功！'),
+    onError: async () => await showError('更新失敗！'),
+  });
+
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({
       title: '確定新增調撥單？',
@@ -134,6 +141,10 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
 
     if (!isConfirmed) return;
     await createMutation.mutateAsync(formData);
+  };
+
+  const onUpdate = async (formData: FormData) => {
+    await updateMutation.mutateAsync(formData);
   };
 
   const exportOrderMutation = useMutation({
@@ -198,7 +209,7 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
         <div className="bg-base-100 h-full w-full text-center">
           {tableBlock}
 
-          {!disabled && (
+          {!disabled ? (
             <div className="bg-base-100 mt-4 flex justify-center gap-2 md:col-span-2">
               <Button
                 className="btn btn-success"
@@ -213,6 +224,12 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
                 onClick={() => router.back()}
               >
                 <XMarkIcon className="w-4"></XMarkIcon> 取消
+              </button>
+            </div>
+          ) : (
+            <div className="bg-base-100 my-4">
+              <button className="btn btn-warning" onClick={handleSubmit(onUpdate)}>
+                修改
               </button>
             </div>
           )}

--- a/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
+++ b/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
@@ -135,7 +135,7 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
   useEffect(() => {
     if (updateMutation.isSuccess) showSuccess('更新成功！');
     if (updateMutation.isError) showError('更新失敗！');
-  }, [updateMutation.isSuccess]);
+  }, [updateMutation.isSuccess, updateMutation.isError]);
 
   const onSubmit = async (formData: FormData) => {
     const { isConfirmed } = await showConfirm({

--- a/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
+++ b/apps/aki-erp/components/transfer/TransferOrderDetail.tsx
@@ -10,6 +10,7 @@ import * as yup from 'yup';
 
 import Button from '@components/shared/Button';
 import { StoreType } from '@constants/artwork.constant';
+import { PAGE_SIZES } from '@constants/page.constant';
 import {
   createTransferOrder,
   exportTransferOrderById,
@@ -195,7 +196,7 @@ const TransferOrderDetail: React.FC<TransferOrderDetailProps> = ({ disabled }) =
                 table.setPageSize(Number(e.target.value));
               }}
             >
-              {[10, 20, 50, 100].map((pageSize) => (
+              {PAGE_SIZES.map((pageSize) => (
                 <option key={pageSize} value={pageSize}>
                   {pageSize} 筆
                 </option>

--- a/apps/aki-erp/constants/artists.formSchema.ts
+++ b/apps/aki-erp/constants/artists.formSchema.ts
@@ -13,10 +13,7 @@ export const formSchema = yup.object().shape({
       const { zhName } = this.parent;
       return !!value?.trim() || !!zhName?.trim();
     }),
-  telephone: yup
-    .string()
-    .required('電話必填')
-    .matches(/^[0-9()-\s]+$/, '不能輸入奇怪的字元'),
+  telephone: yup.string(),
   metadata: yup.object().shape({
     email: yup.string().email('Email 格式錯誤'),
   }),

--- a/apps/aki-erp/constants/artwork.constant.ts
+++ b/apps/aki-erp/constants/artwork.constant.ts
@@ -15,6 +15,14 @@ export const assetsTypeOptions = [
   { label: 'C', value: 'C' },
 ] as const;
 
+export const warehouseMap = {
+  0: 'A',
+  1: 'B',
+  2: 'C',
+  3: 'D',
+  4: 'E',
+} as Record<number, string>;
+
 export const storeTypeOptions = [
   {
     label: '無',

--- a/apps/aki-erp/constants/page.constant.ts
+++ b/apps/aki-erp/constants/page.constant.ts
@@ -1,0 +1,3 @@
+export const PAGE_SIZES = [10, 20, 50, 100];
+
+export const DEFAULT_PAGE_SIZE = 20;

--- a/apps/aki-erp/data-access/apis/artworks.api.ts
+++ b/apps/aki-erp/data-access/apis/artworks.api.ts
@@ -118,7 +118,7 @@ export async function fetchArtworkList(
       if (key === 'agentGalleries') return `metadatas={"agentGalleries":"[{'name':'${value}'}]"}`;
       if (key === 'pageIndex') {
         const pageIndex = +(searchParams?.get('pageIndex') || 0);
-        const pageSize = +(searchParams?.get('pageSize') || 50);
+        const pageSize = +(searchParams?.get('pageSize') || 20);
         return `offset=${pageIndex * pageSize}`;
       }
       if (key === 'pageSize') return `take=${value}`;

--- a/apps/aki-erp/data-access/apis/artworks.api.ts
+++ b/apps/aki-erp/data-access/apis/artworks.api.ts
@@ -11,6 +11,7 @@ import {
   Pagination,
 } from '@data-access/models';
 
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import { fetchCountryList } from './countries.api';
 
 export async function fetchSelectOptions() {
@@ -118,7 +119,7 @@ export async function fetchArtworkList(
       if (key === 'agentGalleries') return `metadatas={"agentGalleries":"[{'name':'${value}'}]"}`;
       if (key === 'pageIndex') {
         const pageIndex = +(searchParams?.get('pageIndex') || 0);
-        const pageSize = +(searchParams?.get('pageSize') || 20);
+        const pageSize = +(searchParams?.get('pageSize') || DEFAULT_PAGE_SIZE);
         return `offset=${pageIndex * pageSize}`;
       }
       if (key === 'pageSize') return `take=${value}`;

--- a/apps/aki-erp/data-access/apis/lend.order.api.ts
+++ b/apps/aki-erp/data-access/apis/lend.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import { CreateOrUpdateLendOrderRequest, LendOrder, Pagination, Status } from '@data-access/models';
 
@@ -19,7 +20,7 @@ export const fetchLendOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/lend.order.api.ts
+++ b/apps/aki-erp/data-access/apis/lend.order.api.ts
@@ -19,7 +19,7 @@ export const fetchLendOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/lend.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/lend.return.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdateLendReturnOrderRequest,
@@ -24,7 +25,7 @@ export const fetchLendReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/lend.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/lend.return.order.api.ts
@@ -24,7 +24,7 @@ export const fetchLendReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/partners.api.ts
+++ b/apps/aki-erp/data-access/apis/partners.api.ts
@@ -7,7 +7,7 @@ export async function fetchPartnerList<
   type,
   keyword,
   pageIndex = 0,
-  pageSize = 50,
+  pageSize = 20,
 }: {
   type?: TPartnerType;
   keyword?: string | null;

--- a/apps/aki-erp/data-access/apis/partners.api.ts
+++ b/apps/aki-erp/data-access/apis/partners.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import { Pagination, Partner, PartnerType } from '@data-access/models';
 
@@ -7,7 +8,7 @@ export async function fetchPartnerList<
   type,
   keyword,
   pageIndex = 0,
-  pageSize = 20,
+  pageSize = DEFAULT_PAGE_SIZE,
 }: {
   type?: TPartnerType;
   keyword?: string | null;

--- a/apps/aki-erp/data-access/apis/purchase.order.api.ts
+++ b/apps/aki-erp/data-access/apis/purchase.order.api.ts
@@ -24,7 +24,7 @@ export const fetchPurchaseOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/purchase.order.api.ts
+++ b/apps/aki-erp/data-access/apis/purchase.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdatePurchaseOrderRequest,
@@ -24,7 +25,7 @@ export const fetchPurchaseOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/purchase.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/purchase.return.order.api.ts
@@ -24,7 +24,7 @@ export const fetchPurchaseReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/purchase.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/purchase.return.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdatePurchaseReturnOrderRequest,
@@ -24,7 +25,7 @@ export const fetchPurchaseReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/repair.order.api.ts
+++ b/apps/aki-erp/data-access/apis/repair.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdateRepairOrderRequest,
@@ -24,7 +25,7 @@ export const fetchRepairOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/repair.order.api.ts
+++ b/apps/aki-erp/data-access/apis/repair.order.api.ts
@@ -24,7 +24,7 @@ export const fetchRepairOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/repair.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/repair.return.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdateRepairReturnOrderRequest,
@@ -24,7 +25,7 @@ export const fetchRepairReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/repair.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/repair.return.order.api.ts
@@ -24,7 +24,7 @@ export const fetchRepairReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/sales.order.api.ts
+++ b/apps/aki-erp/data-access/apis/sales.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdateSalesOrderRequest,
@@ -24,7 +25,7 @@ export const fetchSalesOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/sales.order.api.ts
+++ b/apps/aki-erp/data-access/apis/sales.order.api.ts
@@ -24,7 +24,7 @@ export const fetchSalesOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/sales.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/sales.return.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdateSalesReturnOrderRequest,
@@ -24,7 +25,7 @@ export const fetchSalesReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/sales.return.order.api.ts
+++ b/apps/aki-erp/data-access/apis/sales.return.order.api.ts
@@ -24,7 +24,7 @@ export const fetchSalesReturnOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/transfer.order.api.ts
+++ b/apps/aki-erp/data-access/apis/transfer.order.api.ts
@@ -24,7 +24,7 @@ export const fetchTransferOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 50);
+      const pageSize = +(params.get('pageSize') || 20);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/transfer.order.api.ts
+++ b/apps/aki-erp/data-access/apis/transfer.order.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import {
   CreateOrUpdateTransferOrderRequest,
@@ -24,7 +25,7 @@ export const fetchTransferOrder = async (
     if (key === 'serialNumbers') return query.append('metadatas', `{"serialNumber":"${value}"}`);
     if (key === 'pageIndex') {
       const pageIndex = +(params.get('pageIndex') || 0);
-      const pageSize = +(params.get('pageSize') || 20);
+      const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
       return query.append('offset', `${pageIndex * pageSize}`);
     }
     if (key === 'pageSize') return query.append('take', value);

--- a/apps/aki-erp/data-access/apis/users.api.ts
+++ b/apps/aki-erp/data-access/apis/users.api.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import axios from '@contexts/axios';
 import { Pagination, User } from '@data-access/models';
 
@@ -6,7 +7,7 @@ const url = '/api/Users';
 export const fetchUsers = async (queryString?: string): Promise<Pagination<User>> => {
   const params = new URLSearchParams(queryString);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 20);
+  const pageSize = +(params.get('pageSize') || DEFAULT_PAGE_SIZE);
   const offset = pageIndex * pageSize;
 
   const res = await axios.get(url);

--- a/apps/aki-erp/data-access/apis/users.api.ts
+++ b/apps/aki-erp/data-access/apis/users.api.ts
@@ -6,7 +6,7 @@ const url = '/api/Users';
 export const fetchUsers = async (queryString?: string): Promise<Pagination<User>> => {
   const params = new URLSearchParams(queryString);
   const pageIndex = +(params.get('pageIndex') || 0);
-  const pageSize = +(params.get('pageSize') || 50);
+  const pageSize = +(params.get('pageSize') || 20);
   const offset = pageIndex * pageSize;
 
   const res = await axios.get(url);

--- a/apps/aki-erp/data-access/hooks/usefetchPartnerList.tsx
+++ b/apps/aki-erp/data-access/hooks/usefetchPartnerList.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import { fetchPartnerList } from '@data-access/apis/partners.api';
 import { PartnerType } from '@data-access/models';
 import { useQuery } from '@tanstack/react-query';
@@ -8,7 +9,7 @@ export const usefetchPartnerList = <
   type,
   keyword,
   pageIndex = 0,
-  pageSize = 20,
+  pageSize = DEFAULT_PAGE_SIZE,
 }: {
   type?: TPartnerType;
   keyword?: string | null;

--- a/apps/aki-erp/data-access/hooks/usefetchPartnerList.tsx
+++ b/apps/aki-erp/data-access/hooks/usefetchPartnerList.tsx
@@ -8,7 +8,7 @@ export const usefetchPartnerList = <
   type,
   keyword,
   pageIndex = 0,
-  pageSize = 50,
+  pageSize = 20,
 }: {
   type?: TPartnerType;
   keyword?: string | null;

--- a/apps/aki-erp/data-access/models/artwork.model.ts
+++ b/apps/aki-erp/data-access/models/artwork.model.ts
@@ -103,6 +103,7 @@ export interface ArtworkMetadata {
   salesPhone?: string;
   salesAddress?: string;
   salesDate?: string;
+  carrier?: string;
 }
 
 interface AgentGallery {

--- a/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
+++ b/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
@@ -103,7 +103,7 @@ const useArtworksOrderTable = ({
       cell: ({ cell }: CellContext<ArtworkDetail, ArtworkDetail['metadata']>) => {
         const { length, width, height } = cell.getValue<ArtworkDetail['metadata']>() || {};
         return length || width || height
-          ? `${length && `長 ${length} cm`} ${width && `x 寬 ${width} cm`} ${
+          ? `${length && `長 ${length}`} ${width && `x 寬 ${width}`} ${
               height && `x 高 ${height} cm`
             }`
           : '無';

--- a/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
+++ b/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
@@ -126,7 +126,7 @@ const useArtworksOrderTable = ({
       },
     },
     {
-      header: '在庫位置',
+      header: '庫存位置',
       accessorKey: 'warehouseId',
       cell: ({ row }) => {
         const data = row.original;

--- a/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
+++ b/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
@@ -188,7 +188,6 @@ const useArtworksOrderTable = ({
     data: [...artworks, ...selectedArtworks],
     totalCount: artworks.length + selectedArtworks.length,
     columns,
-    disabled,
     isLoading: disabled ? isLoading : false,
   });
 

--- a/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
+++ b/apps/aki-erp/utils/hooks/useArtworksOrderTable.tsx
@@ -3,16 +3,13 @@
 import { useState } from 'react';
 
 import { ArtworksOrderAddBtn } from '@components/artworks';
-import {
-  assetsTypeOptionMap,
-  salesTypeOptionMap,
-  storeTypeOptionMap,
-} from '@constants/artwork.constant';
+import { assetsTypeOptionMap, salesTypeOptionMap } from '@constants/artwork.constant';
 import { createOrUpdateArtworkDetail } from '@data-access/apis';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/20/solid';
 import { useMutation } from '@tanstack/react-query';
 import { CellContext, ColumnDef } from '@tanstack/react-table';
 import { useTable } from '@utils/hooks';
+import { showStoreTypeText } from '@utils/showStoreTypeText';
 import { ArtworkDetail } from 'data-access/models';
 import Link from 'next/link';
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components';
@@ -159,8 +156,8 @@ const useArtworksOrderTable = ({
       header: '庫存狀態',
       accessorKey: 'metadata',
       cell: ({ cell }: CellContext<ArtworkDetail, ArtworkDetail['metadata']>) => {
-        const storeTypeId = cell.getValue()?.storeType ?? 'inStock';
-        return storeTypeOptionMap[storeTypeId].label;
+        const storeTypeId = cell.getValue()?.storeType;
+        return showStoreTypeText(storeTypeId);
       },
     },
     {

--- a/apps/aki-erp/utils/hooks/useTable.tsx
+++ b/apps/aki-erp/utils/hooks/useTable.tsx
@@ -1,6 +1,7 @@
 import Table from '@components/shared/Table';
 import TablePagination from '@components/shared/TablePagination';
 import { IndeterminateCheckbox } from '@components/shared/field';
+import { DEFAULT_PAGE_SIZE } from '@constants/page.constant';
 import {
   ColumnDef,
   PaginationState,
@@ -33,19 +34,21 @@ const useTable = <T = any,>({
 
   const params = new URLSearchParams(searchParams);
   const [{ pageSize, pageIndex }, setPagination] = useState<PaginationState>({
-    pageSize: +(params.get('pageSize') || 20),
+    pageSize: +(params.get('pageSize') || DEFAULT_PAGE_SIZE),
     pageIndex: +(params.get('pageIndex') || 0),
   });
 
   useEffect(() => {
     if (
-      pageSize === +(params.get('pageSize') || 20) &&
+      pageSize === +(params.get('pageSize') || DEFAULT_PAGE_SIZE) &&
       pageIndex === +(params.get('pageIndex') || 0)
     ) {
       return;
     }
 
-    pageSize !== 20 ? params.set('pageSize', `${pageSize}`) : params.delete('pageSize');
+    pageSize !== DEFAULT_PAGE_SIZE
+      ? params.set('pageSize', `${pageSize}`)
+      : params.delete('pageSize');
     pageIndex > 0 ? params.set('pageIndex', `${pageIndex}`) : params.delete('pageIndex');
 
     router.push(`${pathname}?${params}`);

--- a/apps/aki-erp/utils/hooks/useTable.tsx
+++ b/apps/aki-erp/utils/hooks/useTable.tsx
@@ -12,7 +12,7 @@ import {
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
-const useTable = <T = any>({
+const useTable = <T = any,>({
   data = [],
   meta,
   columns,
@@ -33,19 +33,19 @@ const useTable = <T = any>({
 
   const params = new URLSearchParams(searchParams);
   const [{ pageSize, pageIndex }, setPagination] = useState<PaginationState>({
-    pageSize: +(params.get('pageSize') || 50),
+    pageSize: +(params.get('pageSize') || 20),
     pageIndex: +(params.get('pageIndex') || 0),
   });
 
   useEffect(() => {
     if (
-      pageSize === +(params.get('pageSize') || 50) &&
+      pageSize === +(params.get('pageSize') || 20) &&
       pageIndex === +(params.get('pageIndex') || 0)
     ) {
       return;
     }
 
-    pageSize !== 50 ? params.set('pageSize', `${pageSize}`) : params.delete('pageSize');
+    pageSize !== 20 ? params.set('pageSize', `${pageSize}`) : params.delete('pageSize');
     pageIndex > 0 ? params.set('pageIndex', `${pageIndex}`) : params.delete('pageIndex');
 
     router.push(`${pathname}?${params}`);

--- a/apps/aki-erp/utils/showStoreTypeText.ts
+++ b/apps/aki-erp/utils/showStoreTypeText.ts
@@ -1,0 +1,9 @@
+import { StoreType, storeTypeOptionMap } from '@constants/artwork.constant';
+
+export const showStoreTypeText = (storeType?: StoreType) => {
+  if (storeType === StoreType.RETURNED_LEND_OR_RETURNED_REPAIR) {
+    return storeTypeOptionMap[StoreType.IN_STOCK].label;
+  }
+
+  return storeTypeOptionMap[storeType || StoreType.IN_STOCK].label;
+};


### PR DESCRIPTION
1. 新增「備註」＆「承運人」欄位
2. 移除多餘的「cm」
3. 在每一個 order 頁面上新增「修改」功能
4. 更改 page size 的預設值為 20 筆，調成跟 api 預設的值一樣
5. 在「進貨單」＆「借出單」＆「維修單」新增「加入退還單」功能